### PR TITLE
fix: StructArray.from_arrays takes Iterable

### DIFF
--- a/pyarrow-stubs/lib.pyi
+++ b/pyarrow-stubs/lib.pyi
@@ -1475,7 +1475,7 @@ class StructArray(Array[dict, StructScalar]):
     def flatten(self, memory_pool: MemoryPool | None = ...) -> list[Array]: ...
     @staticmethod
     def from_arrays(
-        arrays: Array,
+        arrays: Iterable[Array],
         names: list[str] | None = ...,
         fields: list[Field] | None = ...,
         mask: BooleanArray | None = ...,


### PR DESCRIPTION
I used an `Iterable` instead of a `Sequence` (as per the docs) because the [code only uses `__iter__`
](https://github.com/apache/arrow/blob/e61c105c73dfabb51d5afc972ff21cc5326b3d93/python/pyarrow/array.pxi#L4069) and `Iterable` is what is being used elsewhere in the stubs.

resolves #42 