### PR TITLE
import parquet.core into parquet __init__.py

### DIFF
--- a/pyarrow-stubs/parquet/__init__.pyi
+++ b/pyarrow-stubs/parquet/__init__.pyi
@@ -1,0 +1,1 @@
+from .core import *  # noqa


### PR DESCRIPTION
Hi there! The latest version seems to have a regression, where `pyarrow.parquet` attributes are not found when running mypy. 

![image](https://github.com/user-attachments/assets/59644a3d-4947-4e91-b4ae-254d9aa2e860)

This fixes the issue on my machine - let me know if you'd like to approach this differently, I saw that this line was explicitly deleted between 10.0.1.9 and 17.0