### PR TITLE
fix: from_pylist covariance

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -12,6 +12,7 @@ from typing import (
     Literal,
     Mapping,
     Self,
+    Sequence,
     TypeAlias,
     TypeVar,
     overload,
@@ -411,7 +412,7 @@ class _Tabular(_PandasConvertible[pd.DataFrame], Generic[_ColumnT]):
     @classmethod
     def from_pylist(
         cls,
-        mapping: list[Mapping[str, Any]],
+        mapping: Sequence[Mapping[str, Any]],
         schema: Schema | None = None,
         metadata: Mapping | None = None,
     ) -> Self: ...


### PR DESCRIPTION
Pyright reports the following correct code as an error:
```python
a = [{"asd": 1}]
pa.Table.from_pylist(a)
```
```
error: Argument of type "list[dict[str, int]]" cannot be assigned to parameter "mapping" of type "list[Mapping[str, Any]]" in function "from_pylist"
    "list[dict[str, int]]" is not assignable to "list[Mapping[str, Any]]"
      Type parameter "_T@list" is invariant, but "dict[str, int]" is not the same as "Mapping[str, Any]"
      Consider switching from "list" to "Sequence" which is covariant (reportArgumentType)
```
This PR fixes this error by following the suggestion in the error report.