### PR TITLE
Add some more StrPath io parts that were overlooked.

### DIFF
--- a/pyarrow-stubs/_parquet.pyi
+++ b/pyarrow-stubs/_parquet.pyi
@@ -367,7 +367,7 @@ class ParquetReader(_Weakrefable):
 class ParquetWriter(_Weakrefable):
     def __init__(
         self,
-        where: str | NativeFile | IO,
+        where: StrPath | NativeFile | IO,
         schema: Schema,
         use_dictionary: bool | list[str] | None = None,
         compression: _Compression | dict[str, _Compression] | None = None,

--- a/pyarrow-stubs/_stubs_typing.pyi
+++ b/pyarrow-stubs/_stubs_typing.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Collection, Literal, Protocol, TypeAlias
+from typing import Any, Collection, Literal, Protocol, TypeAlias, TypeVar
 
 import numpy as np
 
@@ -25,6 +25,9 @@ NullEncoding: TypeAlias = Literal["mask", "encode"]
 NullSelectionBehavior: TypeAlias = Literal["drop", "emit_null"]
 Mask: TypeAlias = list[bool | None] | NDArray[np.bool_] | BooleanArray
 Indices: TypeAlias = list[int] | NDArray[np.integer] | IntegerArray
+
+_T = TypeVar("_T")
+SingleOrList: TypeAlias = list[_T] | _T
 
 class SupportEq(Protocol):
     def __eq__(self, other) -> bool: ...

--- a/pyarrow-stubs/dataset.pyi
+++ b/pyarrow-stubs/dataset.pyi
@@ -193,7 +193,7 @@ def dataset(
 ) -> InMemoryDataset: ...
 def write_dataset(
     data: Dataset | Table | RecordBatch | RecordBatchReader | list[Table] | Iterable[RecordBatch],
-    base_dir: str,
+    base_dir: StrPath,
     *,
     basename_template: str | None = None,
     format: FileFormat | _DatasetFormat | None = None,

--- a/pyarrow-stubs/orc.pyi
+++ b/pyarrow-stubs/orc.pyi
@@ -83,7 +83,7 @@ def read_table(
 ) -> Table: ...
 def write_table(
     table: Table,
-    where: str | NativeFile | IO,
+    where: StrPath | NativeFile | IO,
     *,
     file_version: str = "0.12",
     batch_size: int = 1024,

--- a/pyarrow-stubs/parquet/core.pyi
+++ b/pyarrow-stubs/parquet/core.pyi
@@ -13,6 +13,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
+from _typeshed import StrPath
 from pyarrow import _parquet
 from pyarrow._compute import Expression
 from pyarrow._fs import FileSystem, SupportedFileSystem
@@ -29,7 +30,7 @@ from pyarrow._parquet import (
     SortingColumn,
     Statistics,
 )
-from pyarrow._stubs_typing import FilterTuple
+from pyarrow._stubs_typing import FilterTuple, SingleOrList
 from pyarrow.dataset import ParquetFileFragment, Partitioning
 from pyarrow.lib import NativeFile, RecordBatch, Schema, Table
 from typing_extensions import deprecated
@@ -179,7 +180,7 @@ class ParquetWriter:
 class ParquetDataset:
     def __init__(
         self,
-        path_or_paths: str | list[str],
+        path_or_paths: SingleOrList[StrPath | NativeFile | IO],
         filesystem: SupportedFileSystem | None = None,
         schema: Schema | None = None,
         *,
@@ -217,7 +218,7 @@ class ParquetDataset:
     def partitioning(self) -> Partitioning: ...
 
 def read_table(
-    source: str | Path | NativeFile | IO,
+    source: SingleOrList[StrPath | NativeFile | IO],
     *,
     columns: list | None = None,
     use_threads: bool = True,


### PR DESCRIPTION
Additionally, add the utility typealias `SingleOrList` that can be used in places where we want a concise type declaration but the there is a large union of types.
