### PR TITLE
Add missing partitioning typing case

### DIFF
--- a/pyarrow-stubs/_dataset.pyi
+++ b/pyarrow-stubs/_dataset.pyi
@@ -351,6 +351,12 @@ class DirectoryPartitioning(KeyValuePartitioning):
         schema: lib.Schema | None = None,
         segment_encoding: Literal["uri", "none"] = "uri",
     ) -> PartitioningFactory: ...
+    def __init__(
+        self,
+        schema: lib.Schema,
+        dictionaries: dict[str, lib.Array] | None = None,
+        segment_encoding: Literal["uri", "none"] = "uri",
+    ) -> None: ...
 
 class HivePartitioning(KeyValuePartitioning):
     def __init__(

--- a/pyarrow-stubs/dataset.pyi
+++ b/pyarrow-stubs/dataset.pyi
@@ -114,6 +114,10 @@ _DatasetFormat: TypeAlias = Literal["parquet", "ipc", "arrow", "feather", "csv"]
 @overload
 def partitioning(
     schema: Schema,
+) -> Partitioning: ...
+@overload
+def partitioning(
+    schema: Schema,
     *,
     flavor: Literal["filename"],
     dictionaries: dict[str, Array] | None = None,


### PR DESCRIPTION
This should now support the examples in the docstring for partitioning.
