### PR TITLE
disallow passing `names` as an argument to table when using dictionaries

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -609,9 +609,16 @@ def record_batch(
     schema: Schema | None = None,
     metadata: Mapping | None = None,
 ) -> RecordBatch: ...
+@overload
 def table(
-    data: dict[str, list | Array]
-    | list[Array | ChunkedArray]
+    data: dict[str, list | Array],
+    schema: Schema | None = None,
+    metadata: Mapping | None = None,
+    nthreads: int | None = None,
+) -> Table: ...
+@overload
+def table(
+    data: list[Array | ChunkedArray]
     | pd.DataFrame
     | SupportArrowArray
     | SupportArrowStream


### PR DESCRIPTION
When you use the names argument in conjunction with the dictionaries you get the following error at runtime
```
ValueError: The 'names' argument is not valid when passing a dictionary
```

We can prevent that with an overload