### PR TITLE
improve coverage for pyarrow.struct typehint

### DIFF
--- a/pyarrow-stubs/__lib_pxi/types.pyi
+++ b/pyarrow-stubs/__lib_pxi/types.pyi
@@ -426,7 +426,7 @@ def dictionary(
     index_type: _IndexT, value_type: _BasicValueT, ordered: _Ordered
 ) -> DictionaryType[_IndexT, _BasicValueT, _Ordered]: ...
 def struct(
-    fields: Iterable[Field | tuple[str, Field]] | Mapping[str, Field],
+    fields: Iterable[Field | tuple[str, Field] | tuple[str, DataType]] | Mapping[str, Field],
 ) -> StructType: ...
 def sparse_union(
     child_fields: list[Field], type_codes: list[int] | None = None


### PR DESCRIPTION
Hey,
I ran into a mypy error and would like to fix it upstream.
This is from the docstring of `pyarrow.struct`.
```
import pyarrow as pa
from typing import List, Tuple

fields: List[Tuple[str, pa.DataType]] = [
    ("f1", pa.int32()),
    ("f2", pa.string()),
]
struct_type = pa.struct(fields)
```
To make the last line pass mypy `Iterable[Tuple[str, DataType]]` needs to be added to the stub.

The actual implementation is even more permissive, is that needed? I.e. `Iterable[Tuple[x]]` works as long as you can feed x into `pyarrow.field`.
(https://github.com/apache/arrow/blob/f9a6edac9f175de3ad993887470dd1dff4f151c1/python/pyarrow/types.pxi#L5195)