### PR TITLE
fix: ipc typing

### DIFF
--- a/pyarrow-stubs/__lib_pxi/ipc.pyi
+++ b/pyarrow-stubs/__lib_pxi/ipc.pyi
@@ -41,9 +41,13 @@ class ReadStats(NamedTuple):
 class IpcReadOptions(_Weakrefable):
     ensure_native_endian: bool
     use_threads: bool
-    include_fields: list
+    included_fields: list[int]
     def __init__(
-        self, *, ensure_native_endian: bool = True, use_threads: bool = True, include_fields: list
+        self,
+        *,
+        ensure_native_endian: bool = True,
+        use_threads: bool = True,
+        included_fields: list[int] | None = None,
     ) -> None: ...
 
 class IpcWriteOptions(_Weakrefable):

--- a/pyarrow-stubs/ipc.pyi
+++ b/pyarrow-stubs/ipc.pyi
@@ -27,7 +27,7 @@ class RecordBatchStreamReader(lib._RecordBatchStreamReader):
         self,
         source: bytes | lib.Buffer | lib.NativeFile | IOBase,
         *,
-        options: IpcReadOptions | None,
+        options: IpcReadOptions | None = None,
         memory_pool: lib.MemoryPool | None = None,
     ) -> None: ...
 
@@ -57,8 +57,8 @@ class RecordBatchFileWriter(lib._RecordBatchFileWriter):
         sink: str | lib.NativeFile | IOBase,
         schema: lib.Schema,
         *,
-        options: IpcReadOptions | None,
-        memory_pool: lib.MemoryPool | None = None,
+        use_legacy_format: bool | None = None,
+        options: IpcWriteOptions | None = None,
     ) -> None: ...
 
 def new_stream(
@@ -71,21 +71,21 @@ def new_stream(
 def open_stream(
     source: bytes | lib.Buffer | lib.NativeFile | IOBase,
     *,
-    options: IpcReadOptions | None,
+    options: IpcReadOptions | None = None,
     memory_pool: lib.MemoryPool | None = None,
 ) -> RecordBatchStreamReader: ...
 def new_file(
     sink: str | lib.NativeFile | IOBase,
     schema: lib.Schema,
     *,
-    options: IpcReadOptions | None,
-    memory_pool: lib.MemoryPool | None = None,
+    use_legacy_format: bool | None = None,
+    options: IpcWriteOptions | None = None,
 ) -> RecordBatchFileWriter: ...
 def open_file(
     source: bytes | lib.Buffer | lib.NativeFile | IOBase,
     footer_offset: int | None = None,
     *,
-    options: IpcReadOptions | None,
+    options: IpcReadOptions | None = None,
     memory_pool: lib.MemoryPool | None = None,
 ) -> RecordBatchFileReader: ...
 def serialize_pandas(


### PR DESCRIPTION
The item type of `pyarrow.lib.IpcReadOptions.included_fields` comes from underlying `CIpcReadOptions` definition https://github.com/apache/arrow/blob/313d11aa94c2be71142b55e3d8bb166d780c19c7/python/pyarrow/includes/libarrow.pxd#L1815