### PR TITLE
fix: Preserve generic in `ChunkedArray.type`

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -52,7 +52,7 @@ from .io import Buffer
 from .ipc import RecordBatchReader
 from .scalar import Int64Scalar, Scalar
 from .tensor import Tensor
-from .types import DataType, _AsPyType, _BasicDataType, _DataTypeT
+from .types import _AsPyType, _BasicDataType, _DataType_CoT, _DataTypeT
 
 _Scalar_CoT = TypeVar("_Scalar_CoT", bound=Scalar, covariant=True)
 
@@ -60,7 +60,7 @@ class ChunkedArray(_PandasConvertible[pd.Series], Generic[_Scalar_CoT]):
     @property
     def data(self) -> Self: ...
     @property
-    def type(self) -> DataType: ...
+    def type(self: ChunkedArray[Scalar[_DataType_CoT]]) -> _DataType_CoT: ...
     def length(self) -> int: ...
     __len__ = length
     def to_string(


### PR DESCRIPTION
Discovered during https://github.com/narwhals-dev/narwhals/pull/2007

I worked around it with this, but seemed simple enough to upstream:
```py
def _type(self: pa.ChunkedArray[pa.Scalar[_DataType_CoT]]) -> _DataType_CoT:
    if TYPE_CHECKING:
        return self[0].type
    return self.type
```