### PR TITLE
fix: Add placeholder annotations to `pc.if_else`

### DIFF
--- a/pyarrow-stubs/_stubs_typing.pyi
+++ b/pyarrow-stubs/_stubs_typing.pyi
@@ -7,6 +7,7 @@ from numpy.typing import NDArray
 from .__lib_pxi.array import BooleanArray, IntegerArray
 
 ArrayLike: TypeAlias = Any
+ScalarLike: TypeAlias = Any
 Order: TypeAlias = Literal["ascending", "descending"]
 JoinType: TypeAlias = Literal[
     "left semi",

--- a/pyarrow-stubs/compute.pyi
+++ b/pyarrow-stubs/compute.pyi
@@ -82,7 +82,7 @@ from pyarrow._compute import register_aggregate_function as register_aggregate_f
 from pyarrow._compute import register_scalar_function as register_scalar_function
 from pyarrow._compute import register_tabular_function as register_tabular_function
 from pyarrow._compute import register_vector_function as register_vector_function
-
+from pyarrow._stubs_typing import ArrayLike, ScalarLike
 from . import lib
 
 _P = ParamSpec("_P")
@@ -1826,7 +1826,14 @@ def choose(indices, /, *values, memory_pool: lib.MemoryPool | None = None): ...
 def coalesce(
     *values: _ScalarOrArrayT, memory_pool: lib.MemoryPool | None = None
 ) -> _ScalarOrArrayT: ...
-def if_else(cond, left, right, /, *, memory_pool: lib.MemoryPool | None = None): ...
+def if_else(
+    cond: ArrayLike | ScalarLike,
+    left: ArrayLike | ScalarLike,
+    right: ArrayLike | ScalarLike,
+    /,
+    *,
+    memory_pool: lib.MemoryPool | None = None,
+) -> ArrayLike | ScalarLike: ...
 
 # ========================= 2.21 Structural transforms =========================
 


### PR DESCRIPTION
This is preferable to *nothing* as `pyright` currently turns the result into `Unknown`.

I don't think there would be a way to statically type this accurately

- https://arrow.apache.org/docs/python/generated/pyarrow.compute.if_else.html
- https://github.com/narwhals-dev/narwhals/blob/dc9fcaa99f179f26b98e81134dd4aab54d1bd462/narwhals/_arrow/series.py#L1115-L1126