### PR TITLE
fix: add `pc.fill_null`

### DIFF
--- a/pyarrow-stubs/compute.pyi
+++ b/pyarrow-stubs/compute.pyi
@@ -1792,6 +1792,9 @@ def choose(indices, /, *values, memory_pool: lib.MemoryPool | None = None): ...
 def coalesce(
     *values: _ScalarOrArrayT, memory_pool: lib.MemoryPool | None = None
 ) -> _ScalarOrArrayT: ...
+
+fill_null = coalesce
+
 def if_else(
     cond: ArrayLike | ScalarLike,
     left: ArrayLike | ScalarLike,


### PR DESCRIPTION
> This is an alias for [`coalesce()`](https://arrow.apache.org/docs/python/generated/pyarrow.compute.coalesce.html#pyarrow.compute.coalesce).

- https://arrow.apache.org/docs/python/generated/pyarrow.compute.fill_null.html
- https://github.com/narwhals-dev/narwhals/blob/05e47b27ebe27b24196cee5956d07748d65a62ee/narwhals/_arrow/series.py#L675