### PR TITLE
fix: Allow Table.from_arrays to take a list containing a mix of Array and ChunkedArray

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -465,7 +465,7 @@ class RecordBatch(_Tabular[Array]):
     @classmethod
     def from_arrays(
         cls,
-        arrays: Collection[Array] | Collection[ChunkedArray],
+        arrays: Collection[Array | ChunkedArray],
         names: list[str] | None = None,
         schema: Schema | None = None,
         metadata: Mapping | None = None,


### PR DESCRIPTION
As per the [docs](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.from_arrays):

> **arrays**: [list](https://docs.python.org/3/library/stdtypes.html#list) of [pyarrow.Array](https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array) or [pyarrow.ChunkedArray](https://arrow.apache.org/docs/python/generated/pyarrow.ChunkedArray.html#pyarrow.ChunkedArray)

See also [the implementation](https://github.com/apache/arrow/blob/aac110d4ef105c671ff5f9224effd53ed629aa8a/python/pyarrow/array.pxi#L389) which supports either, and doesn't require they all be of the same type.

This means the following will now type check ok:

```
def mix(a: pa.Array, b: pa.ChunkedArray) -> pa.Table:
    return pa.Table.from_arrays([a,b])
```

Rather than return the pyright error:
```
Argument of type "list[Array[Unknown] | ChunkedArray[Unknown]]" cannot be assigned to parameter "arrays" of type "Collection[Array[Unknown]] | Collection[ChunkedArray[Unknown]]" in function "from_arrays"
  "ChunkedArray[Unknown]" is not assignable to "Array[Unknown]"
  ```