### PR TITLE
fix: from_arrays for both Table and RecordBatch

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -465,7 +465,7 @@ class RecordBatch(_Tabular[Array]):
     @classmethod
     def from_arrays(
         cls,
-        arrays: Collection[Array | ChunkedArray],
+        arrays: Collection[Array],
         names: list[str] | None = None,
         schema: Schema | None = None,
         metadata: Mapping | None = None,
@@ -546,7 +546,7 @@ class Table(_Tabular[ChunkedArray]):
     @classmethod
     def from_arrays(
         cls,
-        arrays: Collection[Array] | Collection[ChunkedArray],
+        arrays: Collection[Array | ChunkedArray],
         names: list[str] | None = None,
         schema: Schema | None = None,
         metadata: Mapping | None = None,


### PR DESCRIPTION
#187 incorrectly applied the change to `RecordBatch.from_arrays`.

This PR fixes that mistake, and applies the change to `Table.from_arrays`.

In addition `RecordBatch.from_arrays` has been corrected to only support `Array` as [per the docs](https://github.com/apache/arrow/blob/7e18764e1f0ce7afddb169863b6b2b35d26b75b2/python/pyarrow/table.pxi#L3469).