### PR TITLE
fix: Include `Array` in `chunked_array` overload

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -202,7 +202,7 @@ def chunked_array(
 ) -> ChunkedArray[scalar.ListScalar]: ...
 @overload
 def chunked_array(
-    values: Iterable[_Scalar_CoT],
+    values: Iterable[_Scalar_CoT] | Iterable[Array[_Scalar_CoT]],
     type: None = None,
 ) -> ChunkedArray[_Scalar_CoT]: ...
 @overload


### PR DESCRIPTION
Discovered after updating to `17.18`
- https://github.com/narwhals-dev/narwhals/pull/2113/commits/0237f7a97abd1f818b20638130d111904d6578f6#diff-e7f4d5fb87ef26f448fcf8288f6c1af28fb035413f3dfcab69242c8e19192736
- https://github.com/narwhals-dev/narwhals/actions/runs/13895880249/job/38876300911?pr=2113

Will mean that this code:

```py
tp = pa.dictionary(pa.int32(), pa.string(), ordered=True)
arr = pa.array(["a", "b"], type=tp)
s = pa.chunked_array([arr], type=tp)
```

Can be reduced to:
```py
tp = pa.dictionary(pa.int32(), pa.string(), ordered=True)
arr = pa.array(["a", "b"], type=tp)
s = pa.chunked_array([arr])
```

And still have the type preserved
