### PR TITLE
Add Scalar, Array and Type classes for Json & Uuid

### DIFF
--- a/pyarrow-stubs/__lib_pxi/array.pyi
+++ b/pyarrow-stubs/__lib_pxi/array.pyi
@@ -1587,11 +1587,8 @@ class ExtensionArray(Array[scalar.ExtensionScalar], Generic[_ArrayT]):
         typ: types.BaseExtensionType, storage: _ArrayT
     ) -> ExtensionArray[_ArrayT]: ...
 
-class JsonArray(ExtensionArray[_ArrayT]):
-    pass
-
-class UuidArray(ExtensionArray[_ArrayT]):
-    pass
+class JsonArray(ExtensionArray[_ArrayT]): ...
+class UuidArray(ExtensionArray[_ArrayT]): ...
 
 class FixedShapeTensorArray(ExtensionArray[_ArrayT]):
     def to_numpy_ndarray(self) -> np.ndarray: ...

--- a/pyarrow-stubs/__lib_pxi/array.pyi
+++ b/pyarrow-stubs/__lib_pxi/array.pyi
@@ -1587,6 +1587,12 @@ class ExtensionArray(Array[scalar.ExtensionScalar], Generic[_ArrayT]):
         typ: types.BaseExtensionType, storage: _ArrayT
     ) -> ExtensionArray[_ArrayT]: ...
 
+class JsonArray(ExtensionArray[_ArrayT]):
+    pass
+
+class UuidArray(ExtensionArray[_ArrayT]):
+    pass
+
 class FixedShapeTensorArray(ExtensionArray[_ArrayT]):
     def to_numpy_ndarray(self) -> np.ndarray: ...
     def to_tensor(self) -> Tensor: ...
@@ -1648,6 +1654,8 @@ __all__ = [
     "StructArray",
     "RunEndEncodedArray",
     "ExtensionArray",
+    "JsonArray",
+    "UuidArray",
     "FixedShapeTensorArray",
     "concat_arrays",
     "_empty_array",

--- a/pyarrow-stubs/__lib_pxi/scalar.pyi
+++ b/pyarrow-stubs/__lib_pxi/scalar.pyi
@@ -257,8 +257,7 @@ class ExtensionScalar(Scalar[types.ExtensionType]):
     @staticmethod
     def from_storage(typ: types.BaseExtensionType, value) -> ExtensionScalar: ...
 
-class JsonScalar(ExtensionScalar):
-    pass
+class JsonScalar(ExtensionScalar): ...
 
 class UuidScalar(ExtensionScalar):
     def as_py(self: Scalar[UuidType]) -> UUID | None: ...

--- a/pyarrow-stubs/__lib_pxi/scalar.pyi
+++ b/pyarrow-stubs/__lib_pxi/scalar.pyi
@@ -4,6 +4,7 @@ import datetime as dt
 import sys
 
 from decimal import Decimal
+from uuid import UUID
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -18,7 +19,7 @@ from typing import Any, Generic, Iterator, Mapping, overload
 import numpy as np
 
 from pyarrow._compute import CastOptions
-from pyarrow.lib import Array, Buffer, MemoryPool, MonthDayNano, Tensor, _Weakrefable
+from pyarrow.lib import Array, Buffer, MemoryPool, MonthDayNano, Tensor, UuidType, _Weakrefable
 from typing_extensions import TypeVar
 
 from . import types
@@ -59,6 +60,8 @@ class Scalar(_Weakrefable, Generic[_DataType_CoT]):
     def validate(self, *, full: bool = False) -> None: ...
     def equals(self, other: Scalar) -> bool: ...
     def __hash__(self) -> int: ...
+    @overload
+    def as_py(self: Scalar[types.ExtensionType]) -> Any: ...
     @overload
     def as_py(self: Scalar[types._BasicDataType[_AsPyType]]) -> _AsPyType: ...
     @overload
@@ -253,6 +256,12 @@ class ExtensionScalar(Scalar[types.ExtensionType]):
     def value(self) -> Any | None: ...
     @staticmethod
     def from_storage(typ: types.BaseExtensionType, value) -> ExtensionScalar: ...
+
+class JsonScalar(ExtensionScalar):
+    pass
+
+class UuidScalar(ExtensionScalar):
+    def as_py(self: Scalar[UuidType]) -> UUID | None: ...
 
 class FixedShapeTensorScalar(ExtensionScalar):
     def to_numpy(self) -> np.ndarray: ...
@@ -453,6 +462,8 @@ __all__ = [
     "RunEndEncodedScalar",
     "UnionScalar",
     "ExtensionScalar",
+    "JsonScalar",
+    "UuidScalar",
     "FixedShapeTensorScalar",
     "scalar",
 ]

--- a/pyarrow-stubs/__lib_pxi/types.pyi
+++ b/pyarrow-stubs/__lib_pxi/types.pyi
@@ -229,6 +229,12 @@ class ExtensionType(BaseExtensionType):
     @classmethod
     def __arrow_ext_deserialize__(cls, storage_type: DataType, serialized: bytes) -> Self: ...
 
+class JsonType(BaseExtensionType):
+    pass
+
+class UuidType(BaseExtensionType):
+    pass
+
 class FixedShapeTensorType(BaseExtensionType, Generic[_ValueT]):
     @property
     def value_type(self) -> _ValueT: ...
@@ -653,6 +659,8 @@ __all__ = [
     "RunEndEncodedType",
     "BaseExtensionType",
     "ExtensionType",
+    "JsonType",
+    "UuidType",
     "FixedShapeTensorType",
     "PyExtensionType",
     "UnknownExtensionType",

--- a/pyarrow-stubs/__lib_pxi/types.pyi
+++ b/pyarrow-stubs/__lib_pxi/types.pyi
@@ -229,11 +229,8 @@ class ExtensionType(BaseExtensionType):
     @classmethod
     def __arrow_ext_deserialize__(cls, storage_type: DataType, serialized: bytes) -> Self: ...
 
-class JsonType(BaseExtensionType):
-    pass
-
-class UuidType(BaseExtensionType):
-    pass
+class JsonType(BaseExtensionType): ...
+class UuidType(BaseExtensionType): ...
 
 class FixedShapeTensorType(BaseExtensionType, Generic[_ValueT]):
     @property


### PR DESCRIPTION
I played around with extension types and found that `pyarrow-stubs` is missing both `JsonType` and `UuidType`.

Also, all -`Array` and -`Scalar` types of that are missing too.

(now I stumbled over [this](https://github.com/zen-xu/pyarrow-stubs/issues/193) issue which is only a few days old)

The problem that I face with this PR is that `ExtensionType` (and `ExtensionScalar` & `ExtensionArray`) IMHO somehow has to be generic over what `.as_py()` (or `.to_pylist()`) can return, since this literally can be anything. In practice only `UuidType`/`UuidScalar` *does* override this (to `UUID | None`), but I wasn't able to make that work for now.

Could you please have a look how to fix this? Sorry!