### PR TITLE
Revert "Add Scalar, Array and Type classes for Json & Uuid"

### DIFF
--- a/pyarrow-stubs/__lib_pxi/array.pyi
+++ b/pyarrow-stubs/__lib_pxi/array.pyi
@@ -1587,9 +1587,6 @@ class ExtensionArray(Array[scalar.ExtensionScalar], Generic[_ArrayT]):
         typ: types.BaseExtensionType, storage: _ArrayT
     ) -> ExtensionArray[_ArrayT]: ...
 
-class JsonArray(ExtensionArray[_ArrayT]): ...
-class UuidArray(ExtensionArray[_ArrayT]): ...
-
 class FixedShapeTensorArray(ExtensionArray[_ArrayT]):
     def to_numpy_ndarray(self) -> np.ndarray: ...
     def to_tensor(self) -> Tensor: ...
@@ -1651,8 +1648,6 @@ __all__ = [
     "StructArray",
     "RunEndEncodedArray",
     "ExtensionArray",
-    "JsonArray",
-    "UuidArray",
     "FixedShapeTensorArray",
     "concat_arrays",
     "_empty_array",

--- a/pyarrow-stubs/__lib_pxi/scalar.pyi
+++ b/pyarrow-stubs/__lib_pxi/scalar.pyi
@@ -4,7 +4,6 @@ import datetime as dt
 import sys
 
 from decimal import Decimal
-from uuid import UUID
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -19,7 +18,7 @@ from typing import Any, Generic, Iterator, Mapping, overload
 import numpy as np
 
 from pyarrow._compute import CastOptions
-from pyarrow.lib import Array, Buffer, MemoryPool, MonthDayNano, Tensor, UuidType, _Weakrefable
+from pyarrow.lib import Array, Buffer, MemoryPool, MonthDayNano, Tensor, _Weakrefable
 from typing_extensions import TypeVar
 
 from . import types
@@ -60,8 +59,6 @@ class Scalar(_Weakrefable, Generic[_DataType_CoT]):
     def validate(self, *, full: bool = False) -> None: ...
     def equals(self, other: Scalar) -> bool: ...
     def __hash__(self) -> int: ...
-    @overload
-    def as_py(self: Scalar[types.ExtensionType]) -> Any: ...
     @overload
     def as_py(self: Scalar[types._BasicDataType[_AsPyType]]) -> _AsPyType: ...
     @overload
@@ -256,11 +253,6 @@ class ExtensionScalar(Scalar[types.ExtensionType]):
     def value(self) -> Any | None: ...
     @staticmethod
     def from_storage(typ: types.BaseExtensionType, value) -> ExtensionScalar: ...
-
-class JsonScalar(ExtensionScalar): ...
-
-class UuidScalar(ExtensionScalar):
-    def as_py(self: Scalar[UuidType]) -> UUID | None: ...
 
 class FixedShapeTensorScalar(ExtensionScalar):
     def to_numpy(self) -> np.ndarray: ...
@@ -461,8 +453,6 @@ __all__ = [
     "RunEndEncodedScalar",
     "UnionScalar",
     "ExtensionScalar",
-    "JsonScalar",
-    "UuidScalar",
     "FixedShapeTensorScalar",
     "scalar",
 ]

--- a/pyarrow-stubs/__lib_pxi/types.pyi
+++ b/pyarrow-stubs/__lib_pxi/types.pyi
@@ -229,9 +229,6 @@ class ExtensionType(BaseExtensionType):
     @classmethod
     def __arrow_ext_deserialize__(cls, storage_type: DataType, serialized: bytes) -> Self: ...
 
-class JsonType(BaseExtensionType): ...
-class UuidType(BaseExtensionType): ...
-
 class FixedShapeTensorType(BaseExtensionType, Generic[_ValueT]):
     @property
     def value_type(self) -> _ValueT: ...
@@ -656,8 +653,6 @@ __all__ = [
     "RunEndEncodedType",
     "BaseExtensionType",
     "ExtensionType",
-    "JsonType",
-    "UuidType",
     "FixedShapeTensorType",
     "PyExtensionType",
     "UnknownExtensionType",


### PR DESCRIPTION
Reverts zen-xu/pyarrow-stubs#194.

JsonArray and UuidArray were added in pyarrow=19.0, but this project has not yet tracked the latest version. So this PR needs to wait until pyarrow-stubs is adapted to 19.0.