### PR TITLE
fix: Add missing `pc.equal` overload

### DIFF
--- a/pyarrow-stubs/compute.pyi
+++ b/pyarrow-stubs/compute.pyi
@@ -966,6 +966,14 @@ def equal(
 ) -> lib.BooleanArray: ...
 @overload
 def equal(
+    x: lib.Array | lib.ChunkedArray,
+    y: lib.Array | lib.ChunkedArray,
+    /,
+    *,
+    memory_pool: lib.MemoryPool | None = None,
+) -> lib.BooleanArray: ...
+@overload
+def equal(
     x: Expression,
     y: Expression,
     /,


### PR DESCRIPTION
Follow-up to #184, resolves 20+ new warnings in `narwhals` on `17.19`

https://github.com/narwhals-dev/narwhals/pull/2233#issuecomment-2729925160