### PR TITLE
fix: Allow `Iterable[Table]` in `concat_tables`

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -630,7 +630,7 @@ def table(
     nthreads: int | None = None,
 ) -> Table: ...
 def concat_tables(
-    tables: list[Table],
+    tables: Iterable[Table],
     memory_pool: MemoryPool | None = None,
     promote_options: Literal["none", "default", "permissive"] = "none",
     **kwargs,


### PR DESCRIPTION
Per the docs (https://arrow.apache.org/docs/python/generated/pyarrow.concat_tables.html)

> tables : iterable of pyarrow.Table objects