### PR TITLE
fix: Allow `ChunkedArray[BooleanScalar]` in `pc.invert`

### DIFF
--- a/pyarrow-stubs/compute.pyi
+++ b/pyarrow-stubs/compute.pyi
@@ -161,6 +161,7 @@ _NumericOrDurationArrayT = TypeVar("_NumericOrDurationArrayT", bound=NumericOrDu
 NumericOrTemporalArray: TypeAlias = ArrayOrChunkedArray[_NumericOrTemporalScalarT]
 _NumericOrTemporalArrayT = TypeVar("_NumericOrTemporalArrayT", bound=NumericOrTemporalArray)
 BooleanArray: TypeAlias = ArrayOrChunkedArray[lib.BooleanScalar]
+_BooleanArrayT = TypeVar("_BooleanArrayT", bound=BooleanArray)
 IntegerArray: TypeAlias = ArrayOrChunkedArray[IntegerScalar]
 _FloatScalarT = TypeVar("_FloatScalarT", bound=FloatScalar)
 FloatArray: TypeAlias = ArrayOrChunkedArray[FloatScalar]
@@ -1092,11 +1093,11 @@ def invert(
 ) -> lib.BooleanScalar: ...
 @overload
 def invert(
-    x: lib.BooleanArray,
+    x: _BooleanArrayT,
     /,
     *,
     memory_pool: lib.MemoryPool | None = None,
-) -> lib.BooleanArray: ...
+) -> _BooleanArrayT: ...
 @overload
 def invert(
     x: Expression,


### PR DESCRIPTION
Fixes https://github.com/narwhals-dev/narwhals/blob/caabc0efdef54f117c83888926860e3972ef69d5/narwhals/_arrow/series.py#L298-L299