### PR TITLE
fix: Add relaxed final overload to logical functions

### DIFF
--- a/pyarrow-stubs/compute.pyi
+++ b/pyarrow-stubs/compute.pyi
@@ -1078,6 +1078,14 @@ def and_(
     *,
     memory_pool: lib.MemoryPool | None = None,
 ) -> Expression: ...
+@overload
+def and_(
+    x: ScalarOrArray[lib.BooleanScalar],
+    y: ScalarOrArray[lib.BooleanScalar],
+    /,
+    *,
+    memory_pool: lib.MemoryPool | None = None,
+) -> ScalarOrArray[lib.BooleanScalar]: ...
 
 and_kleene = _clone_signature(and_)
 and_not = _clone_signature(and_)


### PR DESCRIPTION
Covers all of `pc.(and_ | and_kleene | and_not | and_not_kleene | or_ | or_kleene | xor)`

Resolves:
- https://github.com/narwhals-dev/narwhals/blob/caabc0efdef54f117c83888926860e3972ef69d5/narwhals/_arrow/series.py#L219-L233
- https://github.com/narwhals-dev/narwhals/blob/caabc0efdef54f117c83888926860e3972ef69d5/narwhals/_arrow/series.py#L662