### PR TITLE
fix: Resolve `Scalar.as_py` warnings for `DictionaryType`

### DIFF
--- a/pyarrow-stubs/__lib_pxi/scalar.pyi
+++ b/pyarrow-stubs/__lib_pxi/scalar.pyi
@@ -72,7 +72,7 @@ class Scalar(_Weakrefable, Generic[_DataType_CoT]):
                 types.DictionaryType[types._IndexT, types._BasicDataType[_AsPyTypeV], Any]
             ]
         ],
-    ) -> list[dict[_AsPyTypeK, _AsPyTypeV]]: ...
+    ) -> list[dict[int, _AsPyTypeV]]: ...
     @overload
     def as_py(
         self: Scalar[
@@ -82,7 +82,7 @@ class Scalar(_Weakrefable, Generic[_DataType_CoT]):
     @overload
     def as_py(
         self: Scalar[types.ListType[types.DictionaryType[types._IndexT, Any, Any]],],
-    ) -> list[dict[_AsPyTypeK, Any]]: ...
+    ) -> list[dict[int, Any]]: ...
     @overload
     def as_py(
         self: Scalar[types.StructType],


### PR DESCRIPTION
> scalar.pyi:75:20 - warning: TypeVar "_AsPyTypeK" appears only once in generic function signature
>     Use "object" instead (reportInvalidTypeVarUse)
> scalar.pyi:85:20 - warning: TypeVar "_AsPyTypeK" appears only once in generic function signature
>     Use "object" instead (reportInvalidTypeVarUse)

Instead just using `int`, which should be all that is possible from:

https://github.com/zen-xu/pyarrow-stubs/blob/02552b81161d19d4aa71d8656b028eefac84612b/pyarrow-stubs/__lib_pxi/types.pyi#L154-L164

https://github.com/zen-xu/pyarrow-stubs/blob/02552b81161d19d4aa71d8656b028eefac84612b/pyarrow-stubs/__lib_pxi/types.pyi#L63-L70