### PR TITLE
fix: Resolve `pa.scalar` overload overlaps

### DIFF
--- a/pyarrow-stubs/__lib_pxi/scalar.pyi
+++ b/pyarrow-stubs/__lib_pxi/scalar.pyi
@@ -267,7 +267,7 @@ class FixedShapeTensorScalar(ExtensionScalar):
 
 _V = TypeVar("_V")
 
-CollectionValue: TypeAlias = list[_V | None] | tuple[_V | None, ...] | set[_V | None]
+CollectionValue: TypeAlias = list[_V] | tuple[_V, ...] | set[_V]
 
 @overload
 def scalar(
@@ -279,28 +279,22 @@ def scalar(
 ) -> BinaryScalar: ...
 @overload
 def scalar(
-    value: bool, *, from_pandas: bool | None = None, memory_pool: MemoryPool | None = None
-) -> BooleanScalar: ...
-@overload
-def scalar(
-    value: int, *, from_pandas: bool | None = None, memory_pool: MemoryPool | None = None
-) -> Int64Scalar: ...
-@overload
-def scalar(
-    value: float, *, from_pandas: bool | None = None, memory_pool: MemoryPool | None = None
-) -> DoubleScalar: ...
+    value: bool | float,
+    *,
+    from_pandas: bool | None = None,
+    memory_pool: MemoryPool | None = None,
+) -> BooleanScalar | Int64Scalar | DoubleScalar: ...
 @overload
 def scalar(
     value: Decimal, *, from_pandas: bool | None = None, memory_pool: MemoryPool | None = None
 ) -> Decimal128Scalar: ...
 @overload
 def scalar(
-    value: dt.datetime, *, from_pandas: bool | None = None, memory_pool: MemoryPool | None = None
-) -> TimestampScalar: ...
-@overload
-def scalar(
-    value: dt.date, *, from_pandas: bool | None = None, memory_pool: MemoryPool | None = None
-) -> Date32Scalar: ...
+    value: dt.datetime | dt.date,
+    *,
+    from_pandas: bool | None = None,
+    memory_pool: MemoryPool | None = None,
+) -> TimestampScalar | Date32Scalar: ...
 @overload
 def scalar(
     value: dt.time, *, from_pandas: bool | None = None, memory_pool: MemoryPool | None = None
@@ -339,60 +333,35 @@ def scalar(
 ) -> ListScalar[types.ListType[types.BinaryType]]: ...
 @overload
 def scalar(
-    value: CollectionValue[bool],
+    value: CollectionValue[float] | CollectionValue[bool],
     *,
     from_pandas: bool | None = None,
     memory_pool: MemoryPool | None = None,
-) -> ListScalar[types.ListType[types.BoolType]]: ...
-@overload
-def scalar(
-    value: CollectionValue[int],
-    *,
-    from_pandas: bool | None = None,
-    memory_pool: MemoryPool | None = None,
-) -> ListScalar[types.ListType[types.Int64Type]]: ...
-@overload
-def scalar(
-    value: CollectionValue[float],
-    *,
-    from_pandas: bool | None = None,
-    memory_pool: MemoryPool | None = None,
-) -> ListScalar[types.ListType[types.Float64Type]]: ...
+) -> (
+    ListScalar[types.ListType[types.Int64Type]]
+    | ListScalar[types.ListType[types.Float64Type]]
+    | ListScalar[types.ListType[types.BoolType]]
+): ...
 @overload
 def scalar(
     value: CollectionValue[Decimal],
     *,
     from_pandas: bool | None = None,
     memory_pool: MemoryPool | None = None,
-) -> ListScalar[types.ListType[types.Decimal32Type]]: ...
+) -> (
+    ListScalar[types.ListType[types.Decimal32Type]]
+    | ListScalar[types.ListType[types.Decimal64Type]]
+    | ListScalar[types.ListType[types.Decimal128Type]]
+): ...
 @overload
 def scalar(
-    value: CollectionValue[Decimal],
+    value: CollectionValue[dt.datetime] | CollectionValue[dt.date],
     *,
     from_pandas: bool | None = None,
     memory_pool: MemoryPool | None = None,
-) -> ListScalar[types.ListType[types.Decimal64Type]]: ...
-@overload
-def scalar(
-    value: CollectionValue[Decimal],
-    *,
-    from_pandas: bool | None = None,
-    memory_pool: MemoryPool | None = None,
-) -> ListScalar[types.ListType[types.Decimal128Type]]: ...
-@overload
-def scalar(
-    value: CollectionValue[dt.datetime],
-    *,
-    from_pandas: bool | None = None,
-    memory_pool: MemoryPool | None = None,
-) -> ListScalar[types.ListType[types.TimestampType]]: ...
-@overload
-def scalar(
-    value: CollectionValue[dt.date],
-    *,
-    from_pandas: bool | None = None,
-    memory_pool: MemoryPool | None = None,
-) -> ListScalar[types.ListType[types.Date32Type]]: ...
+) -> (
+    ListScalar[types.ListType[types.TimestampType]] | ListScalar[types.ListType[types.Date32Type]]
+): ...
 @overload
 def scalar(
     value: CollectionValue[dt.time],
@@ -416,7 +385,7 @@ def scalar(
 ) -> ListScalar[types.ListType[types.MonthDayNanoIntervalType]]: ...
 @overload
 def scalar(
-    value: CollectionValue,
+    value: CollectionValue[Any],
     *,
     from_pandas: bool | None = None,
     memory_pool: MemoryPool | None = None,

--- a/pyarrow-stubs/lib.pyi
+++ b/pyarrow-stubs/lib.pyi
@@ -1,5 +1,14 @@
 # ruff: noqa: F403
-from typing import NamedTuple
+import sys
+
+from typing import Any, Final, Literal, Sequence, final
+
+from _typeshed import SupportsAdd, SupportsAllComparisons, SupportsMul, SupportsRMul
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from .__lib_pxi.array import *
 from .__lib_pxi.benchmark import *
@@ -17,10 +26,28 @@ from .__lib_pxi.table import *
 from .__lib_pxi.tensor import *
 from .__lib_pxi.types import *
 
-class MonthDayNano(NamedTuple):
-    days: int
-    months: int
-    nanoseconds: int
+@final
+class MonthDayNano(
+    Sequence[int],
+    SupportsAdd[Sequence[int], Sequence[int]],
+    SupportsAllComparisons,
+    SupportsMul[int, Sequence[int]],
+    SupportsRMul[int, Sequence[int]],
+):
+    n_fields: Final[Literal[3]]
+    n_unnamed_fields: Final[Literal[0]]
+    n_sequence_fields: Final[Literal[3]]
+    if sys.version_info >= (3, 10):
+        __match_args__: Final = ("months", "days", "nanoseconds")
+    @property
+    def months(self) -> int: ...
+    @property
+    def days(self) -> int: ...
+    @property
+    def nanoseconds(self) -> int: ...
+    def __new__(cls, iterable: tuple[int, int, int], /) -> Self: ...
+    if sys.version_info >= (3, 13):
+        def __replace__(self, **kwargs: Any) -> Self: ...
 
 def cpu_count() -> int: ...
 def set_cpu_count(count: int) -> None: ...


### PR DESCRIPTION
- Avoids 18 warnings from `pyright`
- very similar to #183
- `MonthDayNano` was a bit tricky, but is based on https://github.com/python/typeshed/blob/a045be8ed62492952595661118af22554c7cbca4/stdlib/_typeshed/__init__.pyi#L316-L333
  - Had to rewrite manually to avoid overload overlaps on `CollectionValue`
  - Has all the properties/members returns by `inspect.getmembers`
  - Signature via `inspect.signature`