### PR TITLE
chore: Ignore `fsspec` `[import-untyped]`

### DIFF
--- a/pyarrow-stubs/_fs.pyi
+++ b/pyarrow-stubs/_fs.pyi
@@ -15,7 +15,7 @@ else:
 
 from typing import Union, overload
 
-from fsspec import AbstractFileSystem
+from fsspec import AbstractFileSystem  # type: ignore[import-untyped]
 
 from .lib import NativeFile, _Weakrefable
 


### PR DESCRIPTION
```py
_fs.pyi:18: error: Skipping analyzing "fsspec": module is installed, but missing library stubs or py.typed marker  [import-untyped]
_fs.pyi:18: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports 
Found 1 error in 1 file (checked 64 source files)
```

## Related
- https://github.com/fsspec/filesystem_spec/issues/625
- https://github.com/fsspec/filesystem_spec/pull/1676