### PR TITLE
fix: Allow `ChunkedArray` in `Table.set_column`

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -42,7 +42,7 @@ from pyarrow._stubs_typing import (
     SupportArrowDeviceArray,
     SupportArrowStream,
 )
-from pyarrow.compute import Expression
+from pyarrow.compute import ArrayOrChunkedArray, Expression
 from pyarrow.interchange.dataframe import _PyArrowDataFrame
 from pyarrow.lib import Device, Field, MemoryManager, MemoryPool, MonthDayNano, Schema
 
@@ -388,7 +388,7 @@ def chunked_array(
     type: Literal["month_day_nano_interval"],
 ) -> ChunkedArray[scalar.MonthDayNanoIntervalScalar]: ...
 
-_ColumnT = TypeVar("_ColumnT", bound=Array | ChunkedArray)
+_ColumnT = TypeVar("_ColumnT", bound=ArrayOrChunkedArray[Any])
 
 class _Tabular(_PandasConvertible[pd.DataFrame], Generic[_ColumnT]):
     def __array__(self, dtype: np.dtype | None = None, copy: bool | None = None) -> np.ndarray: ...
@@ -410,7 +410,7 @@ class _Tabular(_PandasConvertible[pd.DataFrame], Generic[_ColumnT]):
     @classmethod
     def from_pydict(
         cls,
-        mapping: Mapping[str, ChunkedArray | Array | list | np.ndarray],
+        mapping: Mapping[str, ArrayOrChunkedArray[Any] | list | np.ndarray],
         schema: Schema | None = None,
         metadata: Mapping | None = None,
     ) -> Self: ...
@@ -443,9 +443,11 @@ class _Tabular(_PandasConvertible[pd.DataFrame], Generic[_ColumnT]):
     def remove_column(self, i: int) -> Self: ...
     def drop_columns(self, columns: str | list[str]) -> Self: ...
     def add_column(
-        self, i: int, field_: str | Field, column: ChunkedArray | Array | list
+        self, i: int, field_: str | Field, column: ArrayOrChunkedArray[Any] | list
     ) -> Self: ...
-    def append_column(self, field_: str | Field, column: ChunkedArray | Array | list) -> Self: ...
+    def append_column(
+        self, field_: str | Field, column: ArrayOrChunkedArray[Any] | list
+    ) -> Self: ...
 
 class RecordBatch(_Tabular[Array]):
     def validate(self, *, full: bool = False) -> None: ...
@@ -524,7 +526,7 @@ JoinType: TypeAlias = Literal[
     "full outer",
 ]
 
-class Table(_Tabular[ChunkedArray]):
+class Table(_Tabular[ChunkedArray[Any]]):
     def validate(self, *, full=False) -> None: ...
     def slice(self, offset=0, length=None) -> Self: ...
     def select(self, columns: list[str] | Indices) -> Self: ...
@@ -549,7 +551,7 @@ class Table(_Tabular[ChunkedArray]):
     @classmethod
     def from_arrays(
         cls,
-        arrays: Collection[Array | ChunkedArray],
+        arrays: Collection[ArrayOrChunkedArray[Any]],
         names: list[str] | None = None,
         schema: Schema | None = None,
         metadata: Mapping | None = None,
@@ -569,7 +571,9 @@ class Table(_Tabular[ChunkedArray]):
     def to_reader(self, max_chunksize: int | None = None) -> RecordBatchReader: ...
     def get_total_buffer_size(self) -> int: ...
     def __sizeof__(self) -> int: ...
-    def set_column(self, i: int, field_: str | Field, column: Array | list) -> Self: ...
+    def set_column(
+        self, i: int, field_: str | Field, column: ArrayOrChunkedArray[Any] | list
+    ) -> Self: ...
     @overload
     def rename_columns(self, names: list[str]) -> Self: ...
     @overload
@@ -619,7 +623,7 @@ def table(
 ) -> Table: ...
 @overload
 def table(
-    data: Collection[Array | ChunkedArray]
+    data: Collection[ArrayOrChunkedArray[Any]]
     | pd.DataFrame
     | SupportArrowArray
     | SupportArrowStream


### PR DESCRIPTION
Also being more consistent with `ArrayOrChunkedArray[Any]` everywhere

Discovered in
- https://github.com/vega/vega-datasets/blob/343b7101391a81190ba24e1e8d62a381d2fef3bd/scripts/species.py#L798-L799