### PR TITLE
fix: Include `VarianceOptions` in `TableGroupBy.aggregate`

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -36,6 +36,7 @@ from pyarrow._compute import (
     FunctionOptions,
     ScalarAggregateOptions,
     TDigestOptions,
+    VarianceOptions,
 )
 from pyarrow._stubs_typing import (
     Indices,
@@ -111,7 +112,7 @@ _AggregationPrefixed: TypeAlias = Literal[
 ]
 Aggregation: TypeAlias = _Aggregation | _AggregationPrefixed
 AggregateOptions: TypeAlias = (
-    ScalarAggregateOptions | CountOptions | TDigestOptions | FunctionOptions
+    ScalarAggregateOptions | CountOptions | TDigestOptions | VarianceOptions | FunctionOptions
 )
 
 UnarySelector: TypeAlias = str


### PR DESCRIPTION
- Follow-up to #197
- Noticed while writing up (https://github.com/narwhals-dev/narwhals/issues/2385)
  - We already use it for `std`, `var` in (https://github.com/narwhals-dev/narwhals/blob/16427440e6d74939c403083b52ce3fb0af7d63c7/narwhals/_arrow/group_by.py#L81-L82)