### PR TITLE
fix: Resolve `bit_wise_and` overlaps

### DIFF
--- a/pyarrow-stubs/compute.pyi
+++ b/pyarrow-stubs/compute.pyi
@@ -617,19 +617,35 @@ def bit_wise_and(
 ) -> _NumericArrayT: ...
 @overload
 def bit_wise_and(
-    x: NumericScalar, y: NumericScalar, /, *, memory_pool: lib.MemoryPool | None = None
-) -> NumericScalar: ...
+    x: NumericScalar, y: _NumericArrayT, /, *, memory_pool: lib.MemoryPool | None = None
+) -> _NumericArrayT: ...
 @overload
 def bit_wise_and(
-    x: NumericArray | NumericScalar,
-    y: NumericArray | NumericScalar,
+    x: _NumericArrayT, y: NumericScalar, /, *, memory_pool: lib.MemoryPool | None = None
+) -> _NumericArrayT: ...
+@overload
+def bit_wise_and(
+    x: Expression,
+    y: Expression,
     /,
     *,
     memory_pool: lib.MemoryPool | None = None,
-) -> NumericArray: ...
+) -> Expression: ...
 @overload
 def bit_wise_and(
-    x: Expression | Any, y: Expression | Any, /, *, memory_pool: lib.MemoryPool | None = None
+    x: Expression,
+    y: NumericScalar | ArrayOrChunkedArray[NumericScalar],
+    /,
+    *,
+    memory_pool: lib.MemoryPool | None = None,
+) -> Expression: ...
+@overload
+def bit_wise_and(
+    x: NumericScalar | ArrayOrChunkedArray[NumericScalar],
+    y: Expression,
+    /,
+    *,
+    memory_pool: lib.MemoryPool | None = None,
 ) -> Expression: ...
 @overload
 def bit_wise_not(


### PR DESCRIPTION
Fixes 3 errors:

```py
compute.pyi:608:5 - error: Overload 1 for "bit_wise_and" overlaps overload 4 and returns an incompatible type (reportOverlappingOverload)
compute.pyi:608:5 - error: Overload 1 for "bit_wise_and" overlaps overload 5 and returns an incompatible type (reportOverlappingOverload)
compute.pyi:620:5 - error: Overload 3 for "bit_wise_and" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)
```

Also covers all 6 of these signatures:
https://github.com/zen-xu/pyarrow-stubs/blob/483ce12bfb8c04329efda62615e3ce03f1e57249/pyarrow-stubs/compute.pyi#L645-L650