### PR TITLE
allow `Table` or `RecordBatch` for dataset

### DIFF
--- a/pyarrow-stubs/dataset.pyi
+++ b/pyarrow-stubs/dataset.pyi
@@ -195,6 +195,17 @@ def dataset(
     exclude_invalid_files: bool | None = None,
     ignore_prefixes: list[str] | None = None,
 ) -> InMemoryDataset: ...
+@overload
+def dataset(
+    source: RecordBatch | Table,
+    schema: Schema | None = None,
+    format: FileFormat | _DatasetFormat | None = None,
+    filesystem: SupportedFileSystem | str | None = None,
+    partitioning: Partitioning | PartitioningFactory | str | list[str] | None = None,
+    partition_base_dir: str | None = None,
+    exclude_invalid_files: bool | None = None,
+    ignore_prefixes: list[str] | None = None,
+) -> InMemoryDataset: ...
 def write_dataset(
     data: Dataset | Table | RecordBatch | RecordBatchReader | list[Table] | Iterable[RecordBatch],
     base_dir: StrPath,


### PR DESCRIPTION
The pyarrow `dataset()` function can take as source a single `Table` or a single `RecordBatch`.


From [the docs](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.dataset.html):

_(List of) batches or tables, iterable of batches, or RecordBatchReader:_


(list of) in parentheses for me means that one can provide a single item, and the code backs it up too

https://github.com/apache/arrow/blob/45918a90a6ca1cf3fd67c256a7d6a240249e555a/python/pyarrow/dataset.py#L779-780


Fixes this type checking error:


```
tests/models/schema_test.py:125: error: No overload variant of "dataset" matches argument type "Table"  [call-overload]
        model=TableModel(dataset=pads.dataset(source=pa.Table.from_pandas(table)),
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/models/schema_test.py:125: note: Possible overload variants:
tests/models/schema_test.py:125: note:     def dataset(source: str | PathLike[str] | Sequence[str | PathLike[str]], schema: Schema | None = ..., format: FileFormat | Literal['parquet', 'ipc', 'arrow', 'feather', 'csv'] | None = ..., filesystem: Any | FileSystem | str | None = ..., partitioning: Partitioning | PartitioningFactory | str | list[str] | None = ..., partition_base_dir: str | None = ..., exclude_invalid_files: bool | None = ..., ignore_prefixes: list[str] | None = ...) -> FileSystemDataset
tests/models/schema_test.py:125: note:     def dataset(source: list[Dataset], schema: Schema | None = ..., format: FileFormat | Literal['parquet', 'ipc', 'arrow', 'feather', 'csv'] | None = ..., filesystem: Any | FileSystem | str | None = ..., partitioning: Partitioning | PartitioningFactory | str | list[str] | None = ..., partition_base_dir: str | None = ..., exclude_invalid_files: bool | None = ..., ignore_prefixes: list[str] | None = ...) -> UnionDataset
tests/models/schema_test.py:125: note:     def dataset(source: Iterable[RecordBatch] | Iterable[Table] | RecordBatchReader, schema: Schema | None = ..., format: FileFormat | Literal['parquet', 'ipc', 'arrow', 'feather', 'csv'] | None = ..., filesystem: Any | FileSystem | str | None = ..., partitioning: Partitioning | PartitioningFactory | str | list[str] | None = ..., partition_base_dir: str | None = ..., exclude_invalid_files: bool | None = ..., ignore_prefixes: list[str] | None = ...) -> InMemoryDataset
```

