### PR TITLE
fix: make ParquetFileFormat constructor args optional

### DIFF
--- a/pyarrow-stubs/_dataset_parquet.pyi
+++ b/pyarrow-stubs/_dataset_parquet.pyi
@@ -36,8 +36,8 @@ class ParquetFileFormat(FileFormat):
     """
     def __init__(
         self,
-        read_options: ParquetReadOptions,
-        default_fragment_scan_options: ParquetFragmentScanOptions,
+        read_options: ParquetReadOptions | None = None,
+        default_fragment_scan_options: ParquetFragmentScanOptions | None = None,
         **kwargs,
     ) -> None: ...
     @property


### PR DESCRIPTION
This appears to have been the case for a long time?