### PR TITLE
Fix type signatures of Fragment.to_batches() and Fragment.to_table().

### DIFF
--- a/pyarrow-stubs/_dataset.pyi
+++ b/pyarrow-stubs/_dataset.pyi
@@ -946,6 +946,7 @@ class Fragment(lib._Weakrefable):
         """
     def to_batches(
         self,
+        schema: lib.Schema | None = None,
         columns: list[str] | None = None,
         filter: Expression | None = None,
         batch_size: int = ...,
@@ -1018,6 +1019,7 @@ class Fragment(lib._Weakrefable):
         """
     def to_table(
         self,
+        schema: lib.Schema | None = None,
         columns: list[str] | None = None,
         filter: Expression | None = None,
         batch_size: int = ...,


### PR DESCRIPTION
The first argment `schema` is missing in the two methods.