### PR TITLE
fix(typing): Use Mapping and Sequence for data in table and record_batch

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -5083,7 +5083,7 @@ class Table(_Tabular[ChunkedArray[Any]]):
         """
 
 def record_batch(
-    data: dict[str, list[Any] | Array[Any]]
+    data: Mapping[str, Sequence[Any] | Array[Any]]
     | Collection[Array[Any]]
     | pd.DataFrame
     | SupportArrowArray
@@ -5226,7 +5226,7 @@ def record_batch(
 
 @overload
 def table(
-    data: dict[str, list[Any] | Array[Any]],
+    data: Mapping[str, Sequence[Any] | Array[Any]],
     schema: Schema | None = None,
     metadata: Mapping[str | bytes, str | bytes] | None = None,
     nthreads: int | None = None,


### PR DESCRIPTION
Generalizes the type hints for the  parameter in the  and  functions.

Using  and  instead of  and  makes the function signatures more flexible, allowing for a wider range of input types that conform to the mapping and sequence protocols.

close: #265