### PR TITLE
`Array.from_buffers` accepts None buffers

### DIFF
--- a/pyarrow-stubs/__lib_pxi/array.pyi
+++ b/pyarrow-stubs/__lib_pxi/array.pyi
@@ -3630,7 +3630,7 @@ class DictionaryArray(Array[scalar.DictionaryScalar[_IndexT, _BasicValueT]]):
     def from_buffers(  # type: ignore[override]
         type: _BasicValueT,
         length: int,
-        buffers: list[Buffer],
+        buffers: list[Buffer | None],
         dictionary: Array | np.ndarray | pd.Series,
         null_count: int = -1,
         offset: int = 0,
@@ -3643,7 +3643,7 @@ class DictionaryArray(Array[scalar.DictionaryScalar[_IndexT, _BasicValueT]]):
         type : pyarrow.DataType
         length : int
             The number of values in the array.
-        buffers : List[Buffer]
+        buffers : List[Buffer | None]
             The buffers backing the indices array.
         dictionary : pyarrow.Array, ndarray or pandas.Series
             The array of values referenced by the indices.

--- a/pyarrow-stubs/__lib_pxi/array.pyi
+++ b/pyarrow-stubs/__lib_pxi/array.pyi
@@ -1845,7 +1845,7 @@ class Array(_PandasConvertible[pd.Series], Generic[_Scalar_co]):
     def from_buffers(
         type: _DataTypeT,
         length: int,
-        buffers: list[Buffer],
+        buffers: list[Buffer | None],
         null_count: int = -1,
         offset=0,
         children: NullableCollection[Array[Scalar[_DataTypeT]]] | None = None,
@@ -1861,7 +1861,7 @@ class Array(_PandasConvertible[pd.Series], Generic[_Scalar_co]):
             The value type of the array.
         length : int
             The number of values in the array.
-        buffers : List[Buffer]
+        buffers : List[Buffer | None]
             The buffers backing this array.
         null_count : int, default -1
             The number of null entries in the array. Negative value means that


### PR DESCRIPTION
Might want to wait until 
 * https://github.com/apache/arrow/pull/49163

has been reviewed/merged.