### PR TITLE
Fix RunEndEncodedArray.from_buffers

### DIFF
--- a/pyarrow-stubs/__lib_pxi/array.pyi
+++ b/pyarrow-stubs/__lib_pxi/array.pyi
@@ -3820,7 +3820,7 @@ class RunEndEncodedArray(Array[scalar.RunEndEncodedScalar[_RunEndType, _BasicVal
     def from_buffers(  # pyright: ignore[reportIncompatibleMethodOverride]
         type: DataType,
         length: int,
-        buffers: list[Buffer],
+        buffers: list[None],
         null_count: int = -1,
         offset=0,
         children: tuple[Array, Array] | None = None,


### PR DESCRIPTION
The docs state

> buffers : List[Buffer]
>     Empty List or [None].

Which is a contradiction, unfortunately. Looking at the code and given [this comment](https://github.com/apache/arrow/pull/49163#issuecomment-4004527299), I suggest to update the stubs. As it stands right now, users can only pass `[]`, but not `[None]`, whereas both are valid.