### PR TITLE
fix: Explicitly annotate RecordBatch._export_to_c to return None

### DIFF
--- a/pyarrow-stubs/__lib_pxi/table.pyi
+++ b/pyarrow-stubs/__lib_pxi/table.pyi
@@ -3424,7 +3424,7 @@ class RecordBatch(_Tabular[Array]):
                [ 4., 40.],
                [nan, nan]])
         """
-    def _export_to_c(self, out_ptr: int, out_schema_ptr: int = 0):
+    def _export_to_c(self, out_ptr: int, out_schema_ptr: int = 0) -> None:
         """
         Export to a C ArrowArray struct, given its pointer.
 


### PR DESCRIPTION
Without this, BasedPyright will resolve this signature as "partially unknown".

See also for comparision: <https://github.com/zen-xu/pyarrow-stubs/blob/148368c532f96f953cf39f34120da9d1043bb4dc/pyarrow-stubs/__lib_pxi/array.pyi#L2232>